### PR TITLE
feat: Adiciona template view e webhook para auto-deploy

### DIFF
--- a/bookstore/settings.py
+++ b/bookstore/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = env('SECRET_KEY')
 DEBUG = env('DEBUG')
 
 # 'DJANGO_ALLOWED_HOSTS' deve ser uma string de hosts separados por espaço no seu .env.dev
-ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['127.0.0.1', 'localhost', 'joaovictorangelo.pythonanywhere.com/'])
+ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS', default=['127.0.0.1', 'localhost', 'joaovictorangelo.pythonanywhere.com'])
 
 
 # Application definition
@@ -60,7 +60,7 @@ ROOT_URLCONF = "bookstore.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(BASE_DIR, "bookstore", "templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -103,6 +103,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/bookstore/templates/hello_world.html
+++ b/bookstore/templates/hello_world.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello, World!</title>
+</head>
+    <body>
+        <h1>Hello, World!</h1>
+    </body>
+</html>

--- a/bookstore/views.py
+++ b/bookstore/views.py
@@ -1,0 +1,27 @@
+from django.http import HttpResponse
+from django.template import loader
+from django.views.decorators.csrf import csrf_exempt
+
+import git
+
+
+@csrf_exempt
+def update(request):
+    if request.method == "POST":
+        '''
+        pass the path of the diectory where your project will be
+        stored on PythonAnywhere in the git.Repo() as parameter.
+        Here the name of my directory is "test.pythonanywhere.com"
+        '''
+        repo = git.Repo('/home/JoaoVictorAngelo/bookstore')
+        origin = repo.remotes.origin
+
+        origin.pull()
+        return HttpResponse("Updated code on PythonAnywhere")
+    else:
+        return HttpResponse("Couldn't update the code on PythonAnywhere")
+
+
+def hello_world(request):
+    template = loader.get_template('hello_world.html')
+    return HttpResponse(template.render())


### PR DESCRIPTION
Implementa duas novas funcionalidades principais:

1. Uma view de 'Hello World' ('/hello/') que renderiza um template HTML.
   - Adiciona o diretório de templates ao settings.py para permitir a renderização de templates a partir da pasta raiz do projeto.

2. Um webhook ('/update_server/') para automatizar o deploy no PythonAnywhere.
   - A view executa um 'git pull' no servidor quando recebe uma requisição POST, acionada por um push no repositório do GitHub.
   - Atualiza o urls.py principal para incluir as rotas para as novas views.